### PR TITLE
change in get_model import method

### DIFF
--- a/django_cached_field/tasks.py
+++ b/django_cached_field/tasks.py
@@ -1,6 +1,12 @@
 from celery import shared_task
 from celery.utils.log import get_task_logger
-from django.db.models import get_model
+try:
+    # Django 1.9
+    from django.apps import apps
+    get_model = apps.get_model
+except ImportError:
+    # Django 1.7 and before
+    from django.db.models import get_model
 import re
 
 


### PR DESCRIPTION
Django 1.8 deprecates and Django 1.9 removes the old get_model import path.